### PR TITLE
datagram_dispatcher: use `MSG_WAITFORONE` in recvmmsg, instead of buggy timeout

### DIFF
--- a/src/net/datagram_dispatcher/datagram_dispatcher_settings.rs
+++ b/src/net/datagram_dispatcher/datagram_dispatcher_settings.rs
@@ -33,7 +33,7 @@ impl Default for DatagramDispatcherSettings {
             maximum_packet_rate: 65536.,
             minimum_rate_window: Duration::from_millis(1),
             maximum_rate_window: Duration::from_millis(2),
-            process_in_tasks: 4,
+            process_in_tasks: 8,
             process_out_tasks: 4,
             route_out_tasks: 2,
             receive_channel_capacity: 16384,

--- a/src/net/datagram_dispatcher/datagram_dispatcher_settings.rs
+++ b/src/net/datagram_dispatcher/datagram_dispatcher_settings.rs
@@ -31,9 +31,9 @@ impl Default for DatagramDispatcherSettings {
         DatagramDispatcherSettings {
             retransmission_delay: Duration::from_millis(100),
             maximum_packet_rate: 65536.,
-            minimum_rate_window: Duration::from_millis(1),
-            maximum_rate_window: Duration::from_millis(2),
-            process_in_tasks: 8,
+            minimum_rate_window: Duration::from_millis(5),
+            maximum_rate_window: Duration::from_millis(10),
+            process_in_tasks: 4,
             process_out_tasks: 4,
             route_out_tasks: 2,
             receive_channel_capacity: 16384,


### PR DESCRIPTION
To be checked more extensively.

 A performant setup to reduce erratic packet loss seems to be:
 1. apply this fix to remove buggy timeout on `recvmmsg`  
 see https://man7.org/linux/man-pages/man2/recvmmsg.2.html#BUGS
 2. use adaptive-rx to reduce the number of interrupts
 `sudo ethtool -C ens5 tx-usecs 256 rx-usecs 256`
